### PR TITLE
Enable low-latency mode for H.264 compression

### DIFF
--- a/WebSocketDemo-Shared/CameraManager.swift
+++ b/WebSocketDemo-Shared/CameraManager.swift
@@ -179,7 +179,9 @@ class CameraManager: NSObject, ObservableObject {
       width: width,
       height: height,
       codecType: kCMVideoCodecType_H264,
-      encoderSpecification: nil,
+      encoderSpecification: [
+        kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue
+      ] as CFDictionary,
       imageBufferAttributes: nil,
       compressedDataAllocator: nil,
       outputCallback: nil,
@@ -215,6 +217,13 @@ class CameraManager: NSObject, ObservableObject {
     err = VTSessionSetProperty(compressionSession, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
     guard err == noErr else {
       print("Warning: VTSessionSetProperty(kVTCompressionPropertyKey_AllowFrameReordering) failed (\(err))")
+      throw NSError(domain: NSOSStatusErrorDomain, code: Int(err))
+    }
+
+    // Require key frames every 2 seconds
+    err = VTSessionSetProperty(compressionSession, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 2 as CFNumber)
+    guard err == noErr else {
+      print("Warning: VTSessionSetProperty(kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration) failed (\(err))")
       throw NSError(domain: NSOSStatusErrorDomain, code: Int(err))
     }
   }


### PR DESCRIPTION
### Public-Facing Changes

Improved H.264 compression settings for better low-latency video.

### Description

```swift
/**
	@constant	kVTVideoEncoderSpecification_EnableLowLatencyRateControl
	@abstract
		Requires that an encoder which supports low-latency operation be selected, and enables low-latency mode.
	@discussion
		Low latency RateControl enforces the following behaviors: 
		- Infinite GOP (all P frames following the beginning IDR).
		- No frame reordering (B frame) or looking ahead.
		- Only High profiles. Levels are left for the encoder to automatically set. 
		- Temporal Layer structure.

		Also see:
			kVTCompressionPropertyKey_AverageBitRate
			kVTCompressionPropertyKey_BaseLayerFrameRateFraction
			kVTEncodeFrameOptionKey_ForceKeyFrame
*/
```